### PR TITLE
Add zuplo copy to public readme

### DIFF
--- a/packages/zuplo/README.md
+++ b/packages/zuplo/README.md
@@ -1,3 +1,13 @@
+<p align="center">
+  <a href="https://zuplo.com">
+    <img src="https://portal.zuplo.com/zuplo.svg" height="96">
+    <h3 align="center">Zuplo</h3>
+  </a>
+</p>
+<p align="center">Zuplo's API Gateway helps small and large teams get APIs to production that are
+fast, secure and with game-changing Developer Experience.</p>
+
+
 # Zuplo
 
 This is a convenience package that bundles the Zuplo CLI and various packages for use with Zuplo.


### PR DESCRIPTION
Adding a brief Zuplo copy to the readme surface via the npm listing