### PR TITLE
fix: Use "with" instead of "assert" in examples/custom-module/bundle.mjs

### DIFF
--- a/examples/custom-module/bundle.mjs
+++ b/examples/custom-module/bundle.mjs
@@ -1,17 +1,17 @@
+import path from "node:path";
 import esbuild from "esbuild";
-import path from "path";
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 for (const dep of Object.keys(packageJson.dependencies)) {
   if (dep !== "zuplo") {
     const entry = import.meta.resolve(dep);
     const projectFolder = new URL(
       path.join("node_modules", dep),
-      import.meta.url,
+      import.meta.url
     ).pathname;
     const outputPath = new URL(
       path.resolve("./modules/third-party", dep),
-      import.meta.url,
+      import.meta.url
     ).pathname;
     const url = new URL(entry);
     await esbuild.build({

--- a/examples/custom-module/modules/hello.ts
+++ b/examples/custom-module/modules/hello.ts
@@ -1,9 +1,9 @@
-import { ZuploContext, ZuploRequest } from "@zuplo/runtime";
+import type { ZuploContext, ZuploRequest } from "@zuplo/runtime";
 import OpenAI from "./third-party/openai";
 
 export default async function echo(
   request: ZuploRequest,
-  context: ZuploContext,
+  context: ZuploContext
 ) {
   const openai = new OpenAI({
     apiKey: process.env["OPENAI_API_KEY"], // This is the default and can be omitted


### PR DESCRIPTION
* Updates to newer versions of node which don't support `assert` - it seems they dropped support for module import assertions sometime last year - https://github.com/nodejs/node/pull/52104. This causes an issue when attempting to run `npm run bundle` in the example:

```
> npm run bundle

> custom-module@1.0.0 bundle
> node ./bundle.mjs

file:///Users/jpmcb/workspace/zuplo/zuplo/examples/custom-module/bundle.mjs:3
import packageJson from "./package.json" assert { type: "json" };
                                         ^^^^^^

SyntaxError: Unexpected identifier 'assert'
    at compileSourceTextModule (node:internal/modules/esm/utils:338:16)
    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:102:18)
    at #translate (node:internal/modules/esm/loader:468:12)
    at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:515:27)
    at async ModuleJob._link (node:internal/modules/esm/module_job:115:19)

Node.js v22.14.0
```

* Includes newest openai bundle in example (as a result of running `npm run bundle` successfully)
* Applies linting