### PR TITLE
Add OpenMeter Example to Examples Section on Website

### DIFF
--- a/examples/examples.json
+++ b/examples/examples.json
@@ -25,6 +25,10 @@
       "title": "Logging"
     },
     {
+      "slug": "monetization",
+      "title": "Monetization"
+    },
+    {
       "slug": "mcp",
       "title": "Model Context Protocol (MCP)"
     },
@@ -47,6 +51,22 @@
 
   ],
   "examples": [
+    {
+      "title": "Remote MCP Server",
+      "slug": "remote-mcp-server",
+      "description": "Create a remote MCP server for an API with authentication and additional security policies.",
+      "categories": ["mcp"],
+      "iconUrl": "https://cdn.zuplo.com/static/logos/icon-pink-framed.png",
+      "date": "2025-06-26"
+    },
+    {
+      "title": "Metering with OpenMeter",
+      "slug": "metered-monetization",
+      "description": "Meter requests, enforce plan limits and monetize your API by integrating Zuplo with OpenMeter.",
+      "categories": ["monetization"],
+      "iconUrl": "https://cdn.zuplo.com/static/logos/icon-pink-framed.png",
+      "date": "2025-07-24"
+    },
     {
       "title": "API Linting",
       "slug": "api-linting",
@@ -142,14 +162,6 @@
       "categories": ["validation", "programmability"],
       "iconUrl": "https://cdn.zuplo.com/static/logos/icon-pink-framed.png",
       "date": "2022-12-22"
-    },
-    {
-      "title": "Remote MCP Server",
-      "slug": "remote-mcp-server",
-      "description": "Create a remote MCP server for an API with authentication and additional security policies.",
-      "categories": ["mcp"],
-      "iconUrl": "https://cdn.zuplo.com/static/logos/icon-pink-framed.png",
-      "date": "2025-06-26"
     }
   ]
 }


### PR DESCRIPTION
Adds the OpenMeter example repo to the main website. Should only be merged once the example is merged.

Depends on https://github.com/zuplo/zuplo/pull/53