### PR TITLE
fix broken link in dev-portal example docs

### DIFF
--- a/examples/dev-portal-with-api-keys/docs/pages/example.mdx
+++ b/examples/dev-portal-with-api-keys/docs/pages/example.mdx
@@ -121,7 +121,7 @@ The server side aspect of this is contained in two files in the example:
 ### Client side
 The connection between the Developer Portal and the API for creating API keys is configured in the `docs/zudoku.config.tsx` file.
 
-[Zuplo's Developer Portals](https://zuplo.com/docs/dev-portal/zudoku/guides/managing-api-keys-and-identities) are powered by [Zudoku](https://zudoku.dev) which provides hooks into the underlying `ApiKeyService` allowing you to customize the functionality.
+[Zuplo's Developer Portals](https://zuplo.com/docs/dev-portal/introduction) are powered by [Zudoku](https://zudoku.dev) which provides hooks into the underlying `ApiKeyService` allowing you to customize the functionality.
 
 In this example, on line 82 of `docs/zudoku.config.tsx` it is the `createKey` hook that is customized.
 


### PR DESCRIPTION
Update URL from /docs/dev-portal/zudoku/guides/managing-api-keys-and-identities to /docs/dev-portal/introduction, matching the fix in README.md from commit fe79ac0.

https://claude.ai/code/session_01YAndLMdsgb17MrfzVakQq4